### PR TITLE
Display recent entries first

### DIFF
--- a/autoload/ctrlp/cmdline.vim
+++ b/autoload/ctrlp/cmdline.vim
@@ -60,6 +60,7 @@ endfunction
 func! ctrlp#cmdline#accept(mode, str)
   call ctrlp#exit()
   silent execute ':'.a:str
+  call histadd('cmd', a:str)
 endfunc
 
 


### PR DESCRIPTION
Reversing the order of the history entries will display the most recent ones with a higher priority.  This is usually a good thing, since the recent entries are most likely the ones I want to repeat. Before, I had to scroll upwards if there were multiple matches.

Of course, it is still a matter of opinion.
