### PR TITLE
leave ctrlp entries searchable despite presence of unprintable characters

### DIFF
--- a/autoload/ctrlp/cmdline.vim
+++ b/autoload/ctrlp/cmdline.vim
@@ -45,7 +45,7 @@ endif
 " Return: command
 function! ctrlp#cmdline#init()
   let type = 'cmd'
-  let entries = map(range(histnr(type), 0, -1), 'histget(type, v:val)')
+  let entries = map(range(histnr(type), 0, -1), 'strtrans(histget(type, v:val))')
   let list = filter(entries, '!empty(v:val)')
   return list
 endfunction


### PR DESCRIPTION
Previously, in the presence of a single unprintable character, searching for a single character yielded no results